### PR TITLE
Fixed a bug that prevented LinuxArgvFinder from being used successfully.

### DIFF
--- a/src/main/java/org/skife/gressil/LinuxArgvFinder.java
+++ b/src/main/java/org/skife/gressil/LinuxArgvFinder.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -26,7 +27,7 @@ class LinuxArgvFinder implements ArgvFinder
         catch (IOException e) {
             throw new IllegalStateException("Unable to access " + procfs_file.getAbsolutePath());
         }
-        return Arrays.asList(cmdline.split("\0"));
+        return new ArrayList<String>(Arrays.asList(cmdline.split("\0")));
     }
 
     private static String readFile(File f) throws IOException


### PR DESCRIPTION
...ultimately caused by LinuxArgvFinder.getArgv returning an immutable List where the calling method was expecting a mutable list
